### PR TITLE
Updated the pH Sensor code

### DIFF
--- a/PH_Do_nodemcu/phdonodemcu.ino
+++ b/PH_Do_nodemcu/phdonodemcu.ino
@@ -10,9 +10,9 @@
 
 #define FIREBASE_HOST "ldr-value.firebaseio.com"
 #define WIFI_SSID "Robic Rufarm"
-#define WIFI_PASSWORD "Robicruf@rm12345"
+#define WIFI_PASSWORD "Rr@201920"
 
-Adafruit_ADS1115 ads;
+Adafruit_ADS1115 ads(0x48);
 
 const float multiplier = 0.0001875F;
 float read_do_zero;
@@ -35,7 +35,7 @@ void setup()
   while (WiFi.status() != WL_CONNECTED)
   {
     Serial.print(".");
-    delay(500);
+    delay(1000);
   }
   Serial.println();
   Serial.print("connected: ");
@@ -63,15 +63,11 @@ void get_ph_val(){
   static unsigned long printTime = millis();
   static float pHValue,voltage;
   if(millis()-samplingTime > samplingInterval){
-    pHArray[pHArrayIndex++]=ads.readADC_SingleEnded(2) * multiplier;
+    pHArray[pHArrayIndex++]=ads.readADC_SingleEnded(0);
     if(pHArrayIndex==ArrayLenth)pHArrayIndex=0;
-    voltage = avergearray(pHArray, ArrayLenth)*5.0/1024;
-    pHValue = 3.5*voltage+Offset;
-    samplingTime=millis();
-  }
-  if(millis() - printTime > printInterval){ //Every 800 milliseconds, print a numerical, convert the state of the LED indicato
-    Serial.print("Voltage:");
-    Serial.print(voltage,2);
+    voltage = (avergearray(pHArray, ArrayLenth)*0.1875)/1000;
+    pHValue = (12.571429 * voltage) - 17.571429;
+    Serial.print("Voltage value ="); Serial.println(voltage);
     Serial.print(" pH value: ");
     Serial.println(pHValue,2);
     Firebase.setFloat ("/devices/12334/pH", pHValue);
@@ -92,13 +88,13 @@ void get_do_val(){
   Serial.print("\t Raw Do2 value is : ");
   Serial.println(abs(do_volt));
   Firebase.setFloat ("/devices/12334/do", volt_new);
-  delay(1000);
+  delay(100);
 }
 
 void calibrate_do(){
   read_do_zero = 0.21 ;
   read_do_air =  1.19;
-  delay(1000);
+  delay(100);
   get_do_val();
 }
 


### PR DESCRIPTION
The pH Sensor board makes use of an analog output. Then the use of an ADS1115 converts the analog signal to 16-bit digital signal. The Signal is then converted to voltage values using the formula
voltage = adc_output *0.1875 /1000
This voltage value has been found out by sending the ADS1115 known voltage values then plotting a graph to find the line of best fit and then use the equation of the line to find out the above formula.

Using these voltage values we can convert it into pH values using various control solutions.
pH_value = 12.571 * voltage - 17.571
This was also calculated using the same concept as above.